### PR TITLE
ID-1150: Feature - Added the function to upload the library to GitHub releases

### DIFF
--- a/.github/workflows/build-aar.yml
+++ b/.github/workflows/build-aar.yml
@@ -3,6 +3,10 @@ name: Android CI/CD Library
 on:
   workflow_dispatch:
 
+env:
+  PACKAGE_NAME: appambit-sdk
+  BUILD_PATH: build/outputs/aar/appambit-sdk-release.aar
+
 permissions:
   contents: write
 
@@ -102,18 +106,18 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew :appambit-sdk:assembleRelease
+      run: ./gradlew :${{ env.PACKAGE_NAME }}:assembleRelease
 
     - name: Rename AAR with version
       run: |
         mkdir -p artifacts
-        cp appambit-sdk/build/outputs/aar/appambit-sdk-release.aar artifacts/appambit-sdk-${{ steps.version.outputs.new_version }}.aar
+        cp ${{ env.PACKAGE_NAME }}/${{ env.BUILD_PATH }} artifacts/${{ env.PACKAGE_NAME }}-${{ steps.version.outputs.new_version }}.aar
 
     - name: Upload AAR artifact
       uses: actions/upload-artifact@v4
       with:
-        name: appambit-sdk-${{ steps.version.outputs.new_version }}
-        path: artifacts/appambit-sdk-${{ steps.version.outputs.new_version }}.aar
+        name: ${{ env.PACKAGE_NAME }}-${{ steps.version.outputs.new_version }}
+        path: artifacts/${{ env.PACKAGE_NAME }}-${{ steps.version.outputs.new_version }}.aar
 
     - name: Create GitHub Release
       if: ${{ github.ref_name == 'main' || github.ref_name == 'master' || github.ref_name == 'feature/added-android-library-tag-release' }}
@@ -122,7 +126,7 @@ jobs:
         tag_name: ${{ steps.version.outputs.new_tag }}
         name: ${{ steps.version.outputs.new_tag }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        files: artifacts/appambit-sdk-${{ steps.version.outputs.new_version }}.aar
+        files: artifacts/${{ env.PACKAGE_NAME }}-${{ steps.version.outputs.new_version }}.aar
         body: |
           ## AppAmbit SDK ${{ steps.version.outputs.new_version }}
           AppAmbit Android package for analytics, crash tracking, and usage monitoring


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🛠️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

The workflow file was modified to generate the library with the AAR extension, so that now, in addition to creating it, it also creates the tag and uploads it as a release.

## Related Tickets & Documents

- [ID-1150](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1210823365363614?focus=true)
- Closes #1150

## QA Instructions, Screenshots, Recordings

1. Go to the Actions section on GitHub.
2. Enable the [workflow](https://github.com/Kava-Up-LLC/appambit-sdk-android/actions/workflows/build-aar.yml) where the workflow for the "feature/added-android-library-tag-release" branch is running.
3. Run it again or make a push to that "feature/added-android-library-tag-release" branch
4. Verify that the library was successfully created and uploaded, and that the information displayed is correct.

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: the test was made on github actions section
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [x] ❌ No
- [ ] ❓ I don't know

## [optional] What gif best describes this PR or how it makes you feel?
![Alt Text](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExd2J6Njh3ZTFnZmMycXY5NDExaTZoZjMyN3FmbnliNTYwNnl3dXJmciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/citBl9yPwnUOs/giphy.gif)