### PR TITLE
ID-1336: Bug Fix: Updated way to get context didcrash method

### DIFF
--- a/appambit-sdk/src/main/java/com/appambit/sdk/CrashHandler.java
+++ b/appambit-sdk/src/main/java/com/appambit/sdk/CrashHandler.java
@@ -16,12 +16,12 @@ import java.util.Locale;
 
 public class CrashHandler implements Thread.UncaughtExceptionHandler {
 
-    private final Context context;
+    private static Context context = null;
     private final Thread.UncaughtExceptionHandler defaultHandler;
     private static final String TAG = CrashHandler.class.getSimpleName();
 
     public CrashHandler(@NonNull Context context) {
-        this.context = context.getApplicationContext();
+        CrashHandler.context = context.getApplicationContext();
         this.defaultHandler = Thread.getDefaultUncaughtExceptionHandler();
     }
 
@@ -105,7 +105,7 @@ public class CrashHandler implements Thread.UncaughtExceptionHandler {
     }
 
     public static boolean didCrashInLastSession() {
-        File flagFile = new File(ServiceLocator.getContext().getFilesDir(), DID_APP_CRASH);
+        File flagFile = new File(context.getFilesDir(), DID_APP_CRASH);
         return flagFile.exists();
     }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] 🛠️ Refactor
* [ ] ✨ Feature
* [x] 🐛 Bug Fix
* [ ] ⚡ Optimization
* [ ] 📚 Documentation Update

## Description

The way of obtaining the context in the didCrashInLastSession() method was changed, thus correcting possible crashes due to trying to use it before the SDK initializes the services.

## Related Tickets & Documents

* [ID-1336](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1211564203600757?focus=true)
* Closes #1336
---

## QA Instructions, Screenshots, Recordings

Add the test line of code to the toast of the didCrashInLastSession() method and check that it does not cause context problems

**MainActivity.java**

```
AppAmbit.start(getApplicationContext(), "");
Toast.makeText(getApplicationContext(), "AppAmbit SDK Version: " + Crashes.didCrashInLastSession(), Toast.LENGTH_LONG).show();
```

---

## Added/updated tests?

* [ ] ✅ Yes
* [x] ❌ No, and this is why: is made using didCrash
* [ ] 🤔 I need help with writing tests

---

## Are there any post deployment tasks we need to perform?

* [ ] 📝 Yes (please add details)
* [x] ❌ No
* [ ] ❓ I don't know

---

## [optional] What gif best describes this PR or how it makes you feel?

![alt](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWY1MnJvYnU0c3Q3YXlsejFiYmRxa2pvNzY5dGt3NWE5b25mZ3l1ZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2JdZtu84rJXb9c8o/giphy.gif)
