### PR TITLE
fix: fixed consumer update issue

### DIFF
--- a/appambit-sdk/src/main/java/com/appambit/sdk/AppAmbit.java
+++ b/appambit-sdk/src/main/java/com/appambit/sdk/AppAmbit.java
@@ -194,6 +194,7 @@ public final class AppAmbit {
         InitializeServices(context);
         registerNetworkCallback(context);
         initializeConsumer();
+        ConsumerService.updateConsumer(null, null);
 
         hasStartedSession = true;
         final Runnable batchesTasks = () -> {
@@ -351,6 +352,7 @@ public final class AppAmbit {
                                 SessionManager.sendEndSessionFromDatabase(null);
                                 SessionManager.sendStartSessionIfExist();
                                 SessionManager.sendBatchSessions(batchTasks);
+                                ConsumerService.updateConsumer(null, null);
                                 if (!BreadcrumbManager.streamCrashSessionsOnly) {
                                     BreadcrumbManager.loadBreadcrumbsFromFile();
                                 }

--- a/appambit-sdk/src/main/java/com/appambit/sdk/services/ConsumerService.java
+++ b/appambit-sdk/src/main/java/com/appambit/sdk/services/ConsumerService.java
@@ -164,11 +164,15 @@ public class ConsumerService {
         }
 
         String storedToken = mStorageService.getDeviceToken();
-        boolean storedPushEnabled = mStorageService.getPushEnabled();
+        Boolean storedPushEnabled = mStorageService.getPushEnabled();
 
         if (StringUtils.isNullOrBlank(storedToken)) {
             Log.d(TAG, "No push-related data to sync. Skipping consumer update.");
             return;
+        }
+
+        if (storedPushEnabled == null) {
+            storedPushEnabled = false;
         }
 
         UpdateConsumer request = new UpdateConsumer(storedToken, storedPushEnabled);
@@ -176,8 +180,13 @@ public class ConsumerService {
 
         ServiceLocator.getExecutorService().execute(() -> {
             try {
-                mApiService.executeRequest(endpoint, Void.class);
-                Log.d(TAG, "Consumer update request sent.");
+                ApiResult<Void> result = mApiService.executeRequest(endpoint, Void.class);
+                if (result != null && result.errorType == ApiErrorType.None) {
+                    Log.d(TAG, "Consumer update request sent.");
+                } else {
+                    ApiErrorType errorType = result != null ? result.errorType : ApiErrorType.Unknown;
+                    Log.w(TAG, "Consumer update request failed: " + errorType);
+                }
             } catch (Exception e) {
                 Log.e(TAG, "Failed to send consumer update request.", e);
             }

--- a/tests/AppAmbitSdkTest/src/test/java/com/appambitsdk/test/unit/ConsumerServiceTest.kt
+++ b/tests/AppAmbitSdkTest/src/test/java/com/appambitsdk/test/unit/ConsumerServiceTest.kt
@@ -1,0 +1,146 @@
+package com.appambitsdk.test.unit
+
+import android.util.Log
+import com.appambit.sdk.ServiceLocator
+import com.appambit.sdk.enums.ApiErrorType
+import com.appambit.sdk.models.app.UpdateConsumer
+import com.appambit.sdk.models.responses.ApiResult
+import com.appambit.sdk.services.ConsumerService
+import com.appambit.sdk.services.interfaces.ApiService
+import com.appambit.sdk.services.interfaces.IEndpoint
+import com.appambit.sdk.utils.AppAmbitTaskFuture
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+import java.util.concurrent.ExecutorService
+
+class ConsumerServiceTest {
+
+    private lateinit var fakeStorable: AnalyticsTest.FakeStorable
+    private lateinit var fakeAppInfoService: AnalyticsTest.FakeAppInfoService
+    private lateinit var mockExecutorService: ExecutorService
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        fakeStorable = AnalyticsTest.FakeStorable()
+        fakeAppInfoService = AnalyticsTest.FakeAppInfoService()
+        mockExecutorService = mockk(relaxed = true)
+
+        every { mockExecutorService.execute(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+
+        mockkStatic(ServiceLocator::class)
+        every { ServiceLocator.getExecutorService() } returns mockExecutorService
+
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(ServiceLocator::class)
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `updateConsumer uses stored token and defaults null pushEnabled to false`() {
+        val apiService = CapturingApiService(ApiErrorType.None)
+        ConsumerService.initialize(fakeStorable, fakeAppInfoService, apiService)
+
+        fakeStorable.putConsumerId("consumer-1")
+        fakeStorable.putDeviceToken("token-1")
+
+        ConsumerService.updateConsumer(null, null)
+
+        assertEquals(1, apiService.executedEndpoints.size)
+
+        val payload = apiService.executedEndpoints.first().getPayload() as UpdateConsumer
+        assertEquals("token-1", readDeviceToken(payload))
+        assertFalse(readPushEnabled(payload))
+    }
+
+    @Test
+    fun `updateConsumer stores incoming values and sends them to endpoint`() {
+        val apiService = CapturingApiService(ApiErrorType.None)
+        ConsumerService.initialize(fakeStorable, fakeAppInfoService, apiService)
+
+        fakeStorable.putConsumerId("consumer-2")
+
+        ConsumerService.updateConsumer("new-token", true)
+
+        assertEquals("new-token", fakeStorable.getDeviceToken())
+        assertTrue(fakeStorable.getPushEnabled() == true)
+        assertEquals(1, apiService.executedEndpoints.size)
+
+        val payload = apiService.executedEndpoints.first().getPayload() as UpdateConsumer
+        assertEquals("new-token", readDeviceToken(payload))
+        assertTrue(readPushEnabled(payload))
+    }
+
+    @Test
+    fun `updateConsumer skips request when consumerId is missing`() {
+        val apiService = CapturingApiService(ApiErrorType.None)
+        ConsumerService.initialize(fakeStorable, fakeAppInfoService, apiService)
+
+        fakeStorable.putDeviceToken("token-3")
+        fakeStorable.putPushEnabled(true)
+
+        ConsumerService.updateConsumer(null, null)
+
+        assertEquals(0, apiService.executedEndpoints.size)
+    }
+
+    private fun readDeviceToken(updateConsumer: UpdateConsumer): String {
+        val f = UpdateConsumer::class.java.getDeclaredField("deviceToken")
+        f.isAccessible = true
+        return f.get(updateConsumer) as String
+    }
+
+    private fun readPushEnabled(updateConsumer: UpdateConsumer): Boolean {
+        val f = UpdateConsumer::class.java.getDeclaredField("pushEnabled")
+        f.isAccessible = true
+        return f.getBoolean(updateConsumer)
+    }
+
+    private class CapturingApiService(
+        private val resultErrorType: ApiErrorType
+    ) : ApiService {
+
+        val executedEndpoints = mutableListOf<IEndpoint>()
+        private var token: String? = UUID.randomUUID().toString()
+
+        override fun <T> executeRequest(endpoint: IEndpoint?, clazz: Class<T>?): ApiResult<T> {
+            if (endpoint != null) {
+                executedEndpoints.add(endpoint)
+            }
+            return ApiResult(null, resultErrorType, null)
+        }
+
+        override fun GetNewToken(): AppAmbitTaskFuture<ApiErrorType> {
+            val future = AppAmbitTaskFuture<ApiErrorType>()
+            future.complete(ApiErrorType.None)
+            return future
+        }
+
+        override fun getToken(): String? = token
+
+        override fun setToken(token: String?) {
+            this.token = token
+        }
+    }
+}


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🛠️ Refactor
- [x] 🐛 Bug Fix
- [x] 📚 Documentation Update

## Related Tickets & Documents

- [ID-1667](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1215130897394809)
- Closes #I1667

## Description

Fixes the consumer sync flow so push state updates are not lost after an offline change when connectivity returns.

### Android impact
- `updateConsumer` now reuses the stored push state safely and no longer skips sync after reconnect.
- The SDK triggers a consumer resync on app start and when network connectivity is restored, which covers the offline -> online recovery path.
- Added handling for nullable stored push state and request-result handling so failures are no longer silently ignored.

## Added/updated tests?

- [x] ✅ Yes
- [ ] ❌ No, and this is why:
- [ ] 🤔 I need help with writing tests

## Tests

- Added unit coverage for the consumer sync behavior.
- Verified the targeted test suite passes.

## Are there any post deployment tasks we need to perform?

- [ ] 📝 Yes
- [x] ❌ No
- [ ] ❓ I don't know

Updated todo list

---
- Fix consumer sync on reconnect after offline push changes
- Add regression coverage for nullable push state and missing consumer ID
- Update repo guidance/docs for the workspace
 